### PR TITLE
[casablanca][CSCwb30136+more] Fixed Content-type request header

### DIFF
--- a/src/components/Operation/Operation.tsx
+++ b/src/components/Operation/Operation.tsx
@@ -89,8 +89,15 @@ export class Operation extends React.Component<OperationProps, OperationState> {
    */
   handleApiCall = ({ queryParams, pathParams, cookieParams, header: headers, body }: Request) => {
     const {
-      operation: { httpVerb, path },
+      operation: { httpVerb, path, requestBody },
     } = this.props;
+
+    const requestBodyContent = requestBody?.content;
+    const activeMimeIdx = requestBodyContent?.activeMimeIdx;
+    const contentType =
+      activeMimeIdx !== undefined && requestBodyContent?.mediaTypes[activeMimeIdx]?.name;
+
+    headers = { 'Content-Type': contentType || 'application/json', ...headers };
 
     const request: RequestInit =
       Object.values(NoRequestBodyHttpVerb)


### PR DESCRIPTION
...to match request body schema name i.e. type i.e. application/json or text/plain or whatever is specified, default is application/json. This solves 415 response status codes.