### PR TITLE
Sidebar search items styles fixes

### DIFF
--- a/src/components/SearchBox/styled.elements.tsx
+++ b/src/components/SearchBox/styled.elements.tsx
@@ -57,7 +57,7 @@ export const SearchIcon = styled((props: { className?: string }) => (
 
 export const SearchResultsBox = styled.div`
   padding: ${props => props.theme.spacing.unit}px 0;
-  background-color: ${({ theme }) => darken(0.05, theme.sidebar.backgroundColor)}};
+  background-color: transparent;
   color: ${props => props.theme.sidebar.textColor};
   max-height: 200px;
   border-top: ${({ theme }) => darken(0.1, theme.sidebar.backgroundColor)}};
@@ -74,11 +74,11 @@ font-size: 14px;
   ${MenuItemLabel} {
     padding-top: 6px;
     padding-bottom: 6px;
-    background-color: #163E58;
+    background-color: transparent;
 
     &:hover,
     &.active {
-      background-color: #13374E;
+      background-color: ${({ theme }) => darken(0.05, theme.sidebar.backgroundColor)}};
     }
 
     > svg {
@@ -92,7 +92,7 @@ export const ClearIcon = styled.i`
   display: inline-block;
   width: ${props => props.theme.spacing.unit * 2}px;
   text-align: center;
-  right: ${props => props.theme.spacing.unit * 4}px;
+  right: ${props => props.theme.spacing.unit * 8}px;
   line-height: 6em;
   vertical-align: middle;
   margin-right: 2px;


### PR DESCRIPTION
- [x] Search background changed to transparent
- [x] Search items background changed to transparent
- [x] Search items active and hover changed to darker theme color
- [x] Search clear icon brought to the left a bit

Before:

![image](https://user-images.githubusercontent.com/37018010/208239957-35cead63-817d-41dc-95bc-a8372770534d.png)

After:

![image](https://user-images.githubusercontent.com/37018010/208240020-9e8bd4f0-8250-40a6-bd82-8a222c2911d3.png)
